### PR TITLE
convert to unittest and fix testSiteBudgetExport references #308

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 virtualenv/
 build/
 node_modules/
+*.pyc
+.idea/*
+package-lock.json
+nose2.cfg

--- a/README
+++ b/README
@@ -1,6 +1,0 @@
-# ROOMs app for Rebuilding Together Peninsula
-
-# Copyright 2010 Luke Stone
-
-# This is an online ordering system for construction captains for the
-# annual Rebuilding Day.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ This is an online ordering system for construction captains for the
 annual Rebuilding Day.
 
 ### Developer Setup
-1. [Install the google sdk](https://cloud.google.com/sdk/docs/)
-1. `git clone git@github.com:babybunny/rebuildingtogethercaptain.git`
-1. `cd rebuildingtogethercaptain`
-1. `virtualenv virtualenv  # this directory name is .gitignored`
-1. `./virtualenv/bin/pip install -r requirements.txt`
-1. `./virtualenv/bin/python run_tests.py /path/to/google-sdk-install`  # run the tests
-1. `./virtualenv/bin/python dev_server.py`  # start a dev server
+1. Install the google sdk (docs: https://cloud.google.com/sdk/docs/)
+1. Ensure PYTHONPATH is configured appropriately by trying to run path_utils.fix_sys_path()
+1. git clone git@github.com:babybunny/rebuildingtogethercaptain.git
+1. cd rebuildingtogethercaptain
+1. virtualenv virtualenv  # this directory name is .gitignored
+1. ./virtualenv/bin/pip install -r requirements.txt
+1. ./virtualenv/bin/python run_tests.py /path/to/google-sdk-install  # run the tests
+1. ./virtualenv/bin/python dev_server.py  # start a dev server

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ This is an online ordering system for construction captains for the
 annual Rebuilding Day.
 
 ### Developer Setup
-1. Install the google sdk (docs: https://cloud.google.com/sdk/docs/)
-1. Ensure PYTHONPATH is configured appropriately by trying to run path_utils.fix_sys_path()
+>PREREQUISITES: git and virualenv
+
 1. git clone git@github.com:babybunny/rebuildingtogethercaptain.git
 1. cd rebuildingtogethercaptain
+1. Install the google sdk (docs: https://cloud.google.com/sdk/docs/)
+1. export PYTHONPATH=/path/to/google/app/engine/sdk  # eg /google/google-cloud-sdk/platform/google_appengine
 1. virtualenv virtualenv  # this directory name is .gitignored
 1. ./virtualenv/bin/pip install -r requirements.txt
-1. ./virtualenv/bin/python run_tests.py /path/to/google-sdk-install  # run the tests
+1. ./virtualenv/bin/python run_tests.py  # run the tests
 1. ./virtualenv/bin/python dev_server.py  # start a dev server

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# ROOMs app for Rebuilding Together Peninsula
+
+*Copyright 2010 Luke Stone*
+
+This is an online ordering system for construction captains for the
+annual Rebuilding Day.
+
+### Developer Setup
+1. [Install the google sdk](https://cloud.google.com/sdk/docs/)
+1. `git clone git@github.com:babybunny/rebuildingtogethercaptain.git`
+1. `cd rebuildingtogethercaptain`
+1. `virtualenv virtualenv  # this directory name is .gitignored`
+1. `./virtualenv/bin/pip install -r requirements.txt`
+1. `./virtualenv/bin/python run_tests.py /path/to/google-sdk-install`  # run the tests
+1. `./virtualenv/bin/python dev_server.py`  # start a dev server

--- a/dev_server.py
+++ b/dev_server.py
@@ -1,0 +1,31 @@
+import argparse
+import sys
+import time
+import subprocess
+import dev_utilities
+
+parser = argparse.ArgumentParser()
+parser.add_argument('dev_appserver_path', default='/google/google-cloud-sdk/bin/dev_appserver.py')
+
+command = ['dev_appserver.py',
+           '--clear_datastore=yes',
+           '--admin_port', '8081',
+           '--api_port', '8082',
+           'app.yaml', '&']
+try:
+    subprocess.call(' '.join(command), shell=True)
+except OSError:
+    raise SystemExit("may not have been able to find dev_appserver.py, make sure your PATH is configured")
+
+time.sleep(6)
+
+dev_utilities.main(8080)
+
+print("check out the local server at http://localhost:8080")
+
+try:
+    while True:
+        time.sleep(1)
+except KeyboardInterrupt:
+    subprocess.call('''ps -ef | grep app.yaml | grep api_port | awk '{print $2}' | xargs kill''', shell=True)
+    sys.exit(0)

--- a/dev_server.py
+++ b/dev_server.py
@@ -16,7 +16,7 @@ except OSError:
 
 time.sleep(6)
 
-dev_utilities.main(8080)
+dev_utilities.init_stubs_and_models(8080)
 
 print("check out the local server at http://localhost:8080")
 

--- a/dev_server.py
+++ b/dev_server.py
@@ -1,11 +1,8 @@
-import argparse
 import sys
 import time
 import subprocess
 import dev_utilities
 
-parser = argparse.ArgumentParser()
-parser.add_argument('dev_appserver_path', default='/google/google-cloud-sdk/bin/dev_appserver.py')
 
 command = ['dev_appserver.py',
            '--clear_datastore=yes',
@@ -13,7 +10,7 @@ command = ['dev_appserver.py',
            '--api_port', '8082',
            'app.yaml', '&']
 try:
-    subprocess.call(' '.join(command), shell=True)
+    return_code = subprocess.call(' '.join(command), shell=True)
 except OSError:
     raise SystemExit("may not have been able to find dev_appserver.py, make sure your PATH is configured")
 
@@ -27,5 +24,5 @@ try:
     while True:
         time.sleep(1)
 except KeyboardInterrupt:
-    subprocess.call('''ps -ef | grep app.yaml | grep api_port | awk '{print $2}' | xargs kill''', shell=True)
+    print("Received KeyboardInterrupt")
     sys.exit(0)

--- a/dev_utilities.py
+++ b/dev_utilities.py
@@ -1,11 +1,6 @@
 import argparse
-
-try:
-  import dev_appserver
-  dev_appserver.fix_sys_path()
-except ImportError:
-  print('Please make sure the App Engine SDK is in your PYTHONPATH.')
-  raise
+import path_utils
+path_utils.fix_sys_path()
 
 from google.appengine.ext import ndb
 from google.appengine.ext.remote_api import remote_api_stub
@@ -13,7 +8,19 @@ from google.appengine.ext.remote_api import remote_api_stub
 from test import test_models
 
 
-def main(port):
+def parse_port_from_command_line_args(default_port=8082):
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--port', type=int,
+                        help='localhost port number, matches API server port in dev_server.sh', default=default_port)
+
+    args = parser.parse_args()
+    return args.port
+
+
+def init_stubs_and_models(port=None):
+  port = port or parse_port_from_command_line_args()
   servername = 'localhost:{}'.format(port)
   print servername
   remote_api_stub.ConfigureRemoteApi(
@@ -33,12 +40,4 @@ def main(port):
 
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(
-      description=__doc__,
-      formatter_class=argparse.RawDescriptionHelpFormatter)
-  parser.add_argument(
-      '--port', help='localhost port number, matches API server port in dev_server.sh', default=8082)
-
-  args = parser.parse_args()
-
-  main(args.port)
+  init_stubs_and_models()

--- a/dev_utilities.py
+++ b/dev_utilities.py
@@ -2,6 +2,7 @@ import argparse
 
 try:
   import dev_appserver
+  dev_appserver.fix_sys_path()
 except ImportError:
   print('Please make sure the App Engine SDK is in your PYTHONPATH.')
   raise

--- a/dev_utilities.py
+++ b/dev_utilities.py
@@ -2,7 +2,6 @@ import argparse
 
 try:
   import dev_appserver
-  dev_appserver.fix_sys_path()
 except ImportError:
   print('Please make sure the App Engine SDK is in your PYTHONPATH.')
   raise

--- a/main.py
+++ b/main.py
@@ -276,6 +276,12 @@ login_required = routes.PathPrefixRoute('/room', [
                   name='StaffNew'),  # TODO
 ])
 
+post_routes = routes.PathPrefixRoute('/room', [
+    webapp2.Route(r'/room/site_budget_export',
+                          staff.SiteBudgetExport,
+                          name='SiteBudgetExport')
+    ])
+
 app = webapp2.WSGIApplication(
     [
         webapp2.Route(r'/',
@@ -285,11 +291,7 @@ app = webapp2.WSGIApplication(
                       Placeholder,
                       name='Help'),  # TODO
         login_required,
-        # This one is left out of login_required so it can be unit tested.
-        # It does require login.  See issue 313.
-        webapp2.Route(r'/room/site_budget_export',
-                      staff.SiteBudgetExport,
-                      name='SiteBudgetExport'),
+        post_routes,
         webapp2.Route(r'/order_delete_confirm',
                       staff.OrderDeleteConfirm,
                       name='OrderDeleteConfirm'),

--- a/path_utils.py
+++ b/path_utils.py
@@ -1,0 +1,9 @@
+def fix_sys_path():
+    try:
+        import dev_appserver
+        if not hasattr(dev_appserver, 'fix_sys_path'):
+            raise SystemExit(
+                "PYTHONPATH contains an invalid dev_appserver, please locate a version with `fix_sys_path`")
+        dev_appserver.fix_sys_path()
+    except ImportError:
+        raise SystemExit("Please make sure the App Engine SDK is in your PYTHONPATH.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,3 @@
-# some of these are for testing only
-beautifulsoup4==4.6.0
-google-api-python-client==1.6.4
-httplib2==0.10.3
-Jinja2==2.9.6
-linecache2==1.0.0
-MarkupSafe==1.0
 nose2==0.6.5
 nose2-gae==0.1.7
-oauth2client==4.1.2
-pyasn1==0.3.6
-pyasn1-modules==0.1.4
-PyYAML==3.12
-rsa==3.4.2
-six==1.11.0
-traceback2==1.4.0
-unittest2==1.1.0
-uritemplate==3.0.0
-waitress==1.0.2
-webapp2==2.5.2
-WebOb==1.7.3
 WebTest==2.0.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+# some of these are for testing only
+beautifulsoup4==4.6.0
+google-api-python-client==1.6.4
+httplib2==0.10.3
+Jinja2==2.9.6
+linecache2==1.0.0
+MarkupSafe==1.0
+nose2==0.6.5
+nose2-gae==0.1.7
+oauth2client==4.1.2
+pyasn1==0.3.6
+pyasn1-modules==0.1.4
+PyYAML==3.12
+rsa==3.4.2
+six==1.11.0
+traceback2==1.4.0
+unittest2==1.1.0
+uritemplate==3.0.0
+waitress==1.0.2
+webapp2==2.5.2
+WebOb==1.7.3
+WebTest==2.0.28

--- a/room/ndb_models.py
+++ b/room/ndb_models.py
@@ -103,7 +103,6 @@ class Captain(ndb.Model):
     search_prefixes = ndb.StringProperty(repeated=True)
 
     def put(self, *a, **k):
-        self.email = self.email.lower()
         prefixes = set()
         if self.name:
             prefixes.add(self.name)

--- a/room/ndb_models.py
+++ b/room/ndb_models.py
@@ -777,7 +777,7 @@ class InventoryItem(ndb.Model):
 
 
 def _GetRateFromArray(default, array, activity_date):
-    if not array or not array[0].split():
+    if not array:
         return default
     activity_date_str = activity_date.isoformat()
     rate = default

--- a/room/ndb_models.py
+++ b/room/ndb_models.py
@@ -778,7 +778,7 @@ class InventoryItem(ndb.Model):
 
 
 def _GetRateFromArray(default, array, activity_date):
-    if not array:
+    if not array or not array[0].split():
         return default
     activity_date_str = activity_date.isoformat()
     rate = default

--- a/room/wsgi_service.py
+++ b/room/wsgi_service.py
@@ -85,7 +85,8 @@ def _StaffModelToMessage(mdl):
 
 def _StaffMessageToModel(msg, mdl):
   mdl.name = msg.name
-  mdl.email = msg.email
+  if msg.email:
+    mdl.email = msg.email.lower()
   mdl.program_selected = msg.program_selected
   mdl.notes = msg.notes
   # can't set "since" or "last_welcome", they are automatic
@@ -127,7 +128,8 @@ def _CaptainModelToMessage(mdl):
 
 def _CaptainMessageToModel(msg, mdl):
   mdl.name = msg.name
-  mdl.email = msg.email
+  if msg.email:
+    mdl.email = msg.email.lower()
   mdl.rooms_id = msg.rooms_id
   mdl.phone_mobile = msg.phone_mobile
   mdl.phone_work = msg.phone_work
@@ -179,7 +181,8 @@ def _SupplierModelToMessage(mdl):
 
 def _SupplierMessageToModel(msg, mdl):
   mdl.name = msg.name
-  mdl.email = msg.email
+  if msg.email:
+    mdl.email = msg.email.lower()
   mdl.address = msg.address
   mdl.phone1 = msg.phone1
   mdl.phone2 = msg.phone2

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,30 +1,13 @@
-import argparse
 import os
-import sys
 import unittest
+import path_utils
+path_utils.fix_sys_path()
 
 THIS_FILES_PATH = os.path.realpath(__file__)
 SOURCE_ROOT = os.path.dirname(THIS_FILES_PATH)
 TEST_DIRECTORY = os.path.join(SOURCE_ROOT, 'test')
 
 assert os.path.isdir(TEST_DIRECTORY) and os.path.exists(os.path.join(TEST_DIRECTORY, 'test_main.py'))
-
-parser = argparse.ArgumentParser()
-parser.add_argument('google_sdk_path', nargs='?',
-                    help='Path to sdk home, eg /google/google-cloud-sdk/platform/google_appengine')
-sdk_path = parser.parse_args().google_sdk_path
-if sdk_path is None:
-    parser.error("google_sdk_path is required")
-if not os.path.isdir(sdk_path):
-    parser.error("google_sdk_path={0} is not a directory".format(sdk_path))
-if 'dev_appserver.py' not in os.listdir(sdk_path):
-    parser.error("google_sdk_path={0} appears to be invalid, should contain dev_appserver.py".format(sdk_path))
-
-
-# https://cloud.google.com/appengine/docs/standard/python/tools/localunittesting
-sys.path.insert(1, sdk_path)
-sys.path.insert(1, os.path.join(sdk_path, 'lib', 'yaml', 'lib'))
-sys.path.insert(1, SOURCE_ROOT)
 
 loader = unittest.TestLoader()
 suite = loader.discover(TEST_DIRECTORY)

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,32 @@
+import argparse
+import os
+import sys
+import unittest
+
+THIS_FILES_PATH = os.path.realpath(__file__)
+SOURCE_ROOT = os.path.dirname(THIS_FILES_PATH)
+TEST_DIRECTORY = os.path.join(SOURCE_ROOT, 'test')
+
+assert os.path.isdir(TEST_DIRECTORY) and os.path.exists(os.path.join(TEST_DIRECTORY, 'test_main.py'))
+
+parser = argparse.ArgumentParser()
+parser.add_argument('google_sdk_path', nargs='?',
+                    help='Path to sdk home, eg /google/google-cloud-sdk/platform/google_appengine')
+sdk_path = parser.parse_args().google_sdk_path
+if sdk_path is None:
+    parser.error("google_sdk_path is required")
+if not os.path.isdir(sdk_path):
+    parser.error("google_sdk_path={0} is not a directory".format(sdk_path))
+if 'dev_appserver.py' not in os.listdir(sdk_path):
+    parser.error("google_sdk_path={0} appears to be invalid, should contain dev_appserver.py".format(sdk_path))
+
+
+# https://cloud.google.com/appengine/docs/standard/python/tools/localunittesting
+sys.path.insert(1, sdk_path)
+sys.path.insert(1, os.path.join(sdk_path, 'lib', 'yaml', 'lib'))
+sys.path.insert(1, SOURCE_ROOT)
+
+loader = unittest.TestLoader()
+suite = loader.discover(TEST_DIRECTORY)
+runner = unittest.TextTestRunner(verbosity=2)
+runner.run(suite)

--- a/test/app_engine_test_utils.py
+++ b/test/app_engine_test_utils.py
@@ -1,0 +1,25 @@
+from google.appengine.ext import testbed
+from google.appengine.ext import ndb
+
+
+def activate_app_engine_testbed():
+    """
+    https://cloud.google.com/appengine/docs/standard/python/tools/localunittesting
+
+    :return: activated testbed
+    :rtype: google.appengine.ext.testbed
+    """
+    tb = testbed.Testbed()
+    tb.activate()
+    tb.init_datastore_v3_stub()
+    tb.init_user_stub()
+    tb.init_memcache_stub()
+    tb.init_images_stub(enable=False)
+    return tb
+
+
+def clear_ndb_cache():
+    """
+    https://cloud.google.com/appengine/docs/standard/python/tools/localunittesting
+    """
+    ndb.get_context().clear_cache()

--- a/test/app_engine_test_utils.py
+++ b/test/app_engine_test_utils.py
@@ -2,7 +2,7 @@ from google.appengine.ext import testbed
 from google.appengine.ext import ndb
 
 
-def activate_app_engine_testbed():
+def activate_app_engine_testbed_and_clear_cache():
     """
     https://cloud.google.com/appengine/docs/standard/python/tools/localunittesting
 
@@ -15,11 +15,5 @@ def activate_app_engine_testbed():
     tb.init_user_stub()
     tb.init_memcache_stub()
     tb.init_images_stub(enable=False)
-    return tb
-
-
-def clear_ndb_cache():
-    """
-    https://cloud.google.com/appengine/docs/standard/python/tools/localunittesting
-    """
     ndb.get_context().clear_cache()
+    return tb

--- a/test/route_lister.py
+++ b/test/route_lister.py
@@ -26,17 +26,13 @@ def get_route_list(router):
 
   routes=[]
   for i in get_routes(router):
-    if hasattr(i, 'handler'):
-      # I think this means it's a route, not a path prefix
-      cur_template = i.template
-      cur_handler  = i.handler
-      cur_method   = i.handler_method
-      cur_doc      = get_doc(cur_handler,cur_method)
-      r={'template':cur_template, 'handler':cur_handler, 'method':cur_method, 'doc':cur_doc, 'name': i.name}
-      routes.append(r)
-    else:
-      r=get_route_list(i)
-      routes.extend(r)
+    assert hasattr(i, 'handler')  # I think this means it's a route, not a path prefix
+    cur_template = i.template
+    cur_handler  = i.handler
+    cur_method   = i.handler_method
+    cur_doc      = get_doc(cur_handler,cur_method)
+    r={'template':cur_template, 'handler':cur_handler, 'method':cur_method, 'doc':cur_doc, 'name': i.name}
+    routes.append(r)
 
   return routes
 

--- a/test/route_lister.py
+++ b/test/route_lister.py
@@ -26,13 +26,17 @@ def get_route_list(router):
 
   routes=[]
   for i in get_routes(router):
-    assert hasattr(i, 'handler')  # I think this means it's a route, not a path prefix
-    cur_template = i.template
-    cur_handler  = i.handler
-    cur_method   = i.handler_method
-    cur_doc      = get_doc(cur_handler,cur_method)
-    r={'template':cur_template, 'handler':cur_handler, 'method':cur_method, 'doc':cur_doc, 'name': i.name}
-    routes.append(r)
+    if hasattr(i, 'handler'):
+      # I think this means it's a route, not a path prefix
+      cur_template = i.template
+      cur_handler  = i.handler
+      cur_method   = i.handler_method
+      cur_doc      = get_doc(cur_handler,cur_method)
+      r={'template':cur_template, 'handler':cur_handler, 'method':cur_method, 'doc':cur_doc, 'name': i.name}
+      routes.append(r)
+    else:
+      r=get_route_list(i)
+      routes.extend(r)
 
   return routes
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -13,8 +13,8 @@ app = TestApp(main.app)
 class WelcomeTest(unittest.TestCase):
 
     def setUp(self):
-        app_engine_test_utils.activate_app_engine_testbed()
-        app_engine_test_utils.clear_ndb_cache()
+        app_engine_test_utils.activate_app_engine_testbed_and_clear_cache()
+
 
     def testHelp(self):
         response = app.get('/help')
@@ -35,11 +35,10 @@ class WelcomeTest(unittest.TestCase):
 
 class StatefulTest(unittest.TestCase):
     def setUp(self):
-        app_engine_test_utils.activate_app_engine_testbed()
-        app_engine_test_utils.clear_ndb_cache()
+        app_engine_test_utils.activate_app_engine_testbed_and_clear_cache()
+
         self.keys = test_models.CreateAll()
-        test_models.CreateAll()        
-                
+
     def testRootXHeaderStaff(self):
         response = app.get('/', headers={'x-rooms-dev-signin-email': 'rebuildingtogether.staff@gmail.com'})
         self.assertEquals('302 Moved Temporarily', response.status)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,20 +1,27 @@
 """Functional tests for main views."""
 
-import unittest2
+import os
+import unittest
 from webtest import TestApp
 import main
 from test import test_models
+import app_engine_test_utils
 
 app = TestApp(main.app)
 
-class WelcomeTest(unittest2.TestCase):
+
+class WelcomeTest(unittest.TestCase):
+
+    def setUp(self):
+        app_engine_test_utils.activate_app_engine_testbed()
+        app_engine_test_utils.clear_ndb_cache()
+
     def testHelp(self):
         response = app.get('/help')
         self.assertEquals('200 OK', response.status)
 
     def testRoot(self):
-        # determines dev user from nose2.cfg
-        # testbed-env = ROOMS_DEV_SIGNIN_EMAIL="rebuildingtogether.nobody@gmail.com"
+        os.environ['ROOMS_DEV_SIGNIN_EMAIL'] = "rebuildingtogether.nobody@gmail.com"
         response = app.get('/')
         self.assertEquals('200 OK', response.status)
         self.assertIn('Welcome to ROOMS', str(response))
@@ -26,8 +33,11 @@ class WelcomeTest(unittest2.TestCase):
         self.assertIn('rebuildingtogether.staff@gmail.com', str(response))
 
 
-class StatefulTest(unittest2.TestCase):
+class StatefulTest(unittest.TestCase):
     def setUp(self):
+        app_engine_test_utils.activate_app_engine_testbed()
+        app_engine_test_utils.clear_ndb_cache()
+        self.keys = test_models.CreateAll()
         test_models.CreateAll()        
                 
     def testRootXHeaderStaff(self):

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -452,8 +452,8 @@ def DeleteAll(KEYS):
 class ModelsTest(unittest.TestCase):
 
   def setUp(self):
-    app_engine_test_utils.activate_app_engine_testbed()
-    app_engine_test_utils.clear_ndb_cache()
+    app_engine_test_utils.activate_app_engine_testbed_and_clear_cache()
+
 
   def testCreate(self):
     KEYS = CreateAll()

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -8,9 +8,9 @@ Also, these models may be used in unit tests.
 
 import datetime
 import logging
-import unittest2
+import unittest
 from room import ndb_models
-
+import app_engine_test_utils
 
 def CreateAll():
   """Creates all the models in this module.
@@ -449,7 +449,12 @@ def DeleteAll(KEYS):
     key.delete()
 
 
-class ModelsTest(unittest2.TestCase):
+class ModelsTest(unittest.TestCase):
+
+  def setUp(self):
+    app_engine_test_utils.activate_app_engine_testbed()
+    app_engine_test_utils.clear_ndb_cache()
+
   def testCreate(self):
     KEYS = CreateAll()
     self.assertTrue(KEYS)

--- a/test/test_ndb_models.py
+++ b/test/test_ndb_models.py
@@ -8,8 +8,8 @@ import app_engine_test_utils
 class ModelsTest(unittest.TestCase):
 
     def setUp(self):
-        app_engine_test_utils.activate_app_engine_testbed()
-        app_engine_test_utils.clear_ndb_cache()
+        app_engine_test_utils.activate_app_engine_testbed_and_clear_cache()
+
         self.keys = test_models.CreateAll()
 
     def tearDown(self):

--- a/test/test_ndb_models.py
+++ b/test/test_ndb_models.py
@@ -1,12 +1,15 @@
 """Unit tests for ndb_models."""
+import unittest
 
-import unittest2
-from room import ndb_models
 import test_models
+import app_engine_test_utils
 
 
-class ModelsTest(unittest2.TestCase):
+class ModelsTest(unittest.TestCase):
+
     def setUp(self):
+        app_engine_test_utils.activate_app_engine_testbed()
+        app_engine_test_utils.clear_ndb_cache()
         self.keys = test_models.CreateAll()
 
     def tearDown(self):

--- a/test/test_staff.py
+++ b/test/test_staff.py
@@ -1,39 +1,55 @@
 """Functional tests for staff views."""
 
 import os
-import unittest2
-import webapp2
+
+import unittest
+import app_engine_test_utils
+
 from webtest import TestApp
 import main
+from room import staff
 from test import test_models
 from test import route_lister
 
-app = TestApp(main.app)
+
+APP = TestApp(main.app)
 
 
-class LoggedInTest(unittest2.TestCase):
+
+class LoggedInTest(unittest.TestCase):
+
+    def setUp(self):
+        app_engine_test_utils.activate_app_engine_testbed()
+        app_engine_test_utils.clear_ndb_cache()
+
     def testStaffHome(self):
-        response = app.get('/room/staff_home')
+        response = APP.get('/room/staff_home')
         self.assertEquals('302 Moved Temporarily', response.status)
         # TODO: this could be more robust.  no guarantee that it's localhost?
         self.assertEquals('http://localhost/', response.headers['Location'])
 
         
-class StatefulTestNoProgram(unittest2.TestCase):
+class StatefulTestNoProgram(unittest.TestCase):
+
     def setUp(self):
+        app_engine_test_utils.activate_app_engine_testbed()
+        app_engine_test_utils.clear_ndb_cache()
         self.keys = test_models.CreateAll()        
                 
     def tearDown(self):
         test_models.DeleteAll(self.keys)
         
     def testHomeXHeaderStaff(self):
-        response = app.get('/room/staff_home', headers={'x-rooms-dev-signin-email': 'rebuildingtogether.staff2@gmail.com'})
+        response = APP.get('/room/staff_home', headers={'x-rooms-dev-signin-email': 'rebuildingtogether.staff2@gmail.com'})
         self.assertEquals('302 Moved Temporarily', response.status)
         self.assertEquals('http://localhost/room/select_program', response.headers['Location'])
         
 
-class StatefulTestCaptain(unittest2.TestCase):
+class StatefulTestCaptain(unittest.TestCase):
+
     def setUp(self):
+        app_engine_test_utils.activate_app_engine_testbed()
+        app_engine_test_utils.clear_ndb_cache()
         self.keys = test_models.CreateAll()        
         s = self.keys['STAFF'].get()
         s.program_selected = '2011 Test'
@@ -43,16 +59,19 @@ class StatefulTestCaptain(unittest2.TestCase):
         test_models.DeleteAll(self.keys)
         
     def _get(self, path):
-        return app.get(path, headers={'x-rooms-dev-signin-email': 'rebuildingtogether.capn@gmail.com'})
+        return APP.get(path, headers={'x-rooms-dev-signin-email': 'rebuildingtogether.capn@gmail.com'})
 
     def testCaptainHome(self):
         response = self._get('/room/captain_home')
         self.assertIn('Ahoy Captain!', response.body)
         
     
-class StatefulTestStaffWithProgram(unittest2.TestCase):
+class StatefulTestStaffWithProgram(unittest.TestCase):
+
     def setUp(self):
-        self.keys = test_models.CreateAll()        
+        app_engine_test_utils.activate_app_engine_testbed()
+        app_engine_test_utils.clear_ndb_cache()
+        self.keys = test_models.CreateAll()
         s = self.keys['STAFF'].get()
         s.program_selected = '2011 Test'
         s.put()
@@ -61,29 +80,51 @@ class StatefulTestStaffWithProgram(unittest2.TestCase):
         test_models.DeleteAll(self.keys)    
 
     def _get(self, path):
-        return app.get(path, headers={'x-rooms-dev-signin-email': 'rebuildingtogether.staff@gmail.com'})
+        return APP.get(path, headers={'x-rooms-dev-signin-email': 'rebuildingtogether.staff@gmail.com'})
+
+    def _post(self, path):
+        return APP.post(path,
+                        headers={'x-rooms-dev-signin-email': 'rebuildingtogether.staff@gmail.com'},
+                        params={'submit': staff.EXPORT_CSV})
         
-    
+
 class StatefulTestStaffWithProgramAuto(StatefulTestStaffWithProgram):
     """Automatically test all routes to ensure they don't crash."""
     _multiprocess_can_split_ = True
 
-def _makerOfTestFunction(path):
-    """Return a test function for the path"""
-    def aTest(self):
-        response = self._get(path)
-        self.assertEquals('200 OK', response.status, msg=str(response))
-    return aTest
+    @staticmethod
+    def get_test_function(path, method):
 
-routes = route_lister.get_route_list(main.login_required)
+        def get(_self):
+            response = _self._get(path)
+            _self.assertEquals('200 OK', response.status, msg=str(response))
 
-for r in routes:
-    if '<' in r['template']:
-        continue  # TODO: figure out how to test paths with id segments.
-    testFunc = _makerOfTestFunction(r['template'])
-    testFunc.__name__ = 'test{}'.format(r['name'])
-    setattr(StatefulTestStaffWithProgramAuto, testFunc.__name__, testFunc)
-        
+        def post(_self):
+            response = _self._post(path)
+            _self.assertEquals('200 OK', response.status, msg=str(response))
+
+        if method == 'GET':
+            return get
+        if method == 'POST':
+            return post
+        raise NotImplementedError('method={0} not supported'.format(method))
+
+    @staticmethod
+    def build():
+        for r in route_lister.get_route_list(main.login_required):
+            if '<' in r['template']:
+                continue  # TODO: figure out how to test paths with id segments.
+            testFunc = StatefulTestStaffWithProgramAuto.get_test_function(r['template'], 'GET')
+            testFunc.__name__ = 'test{}'.format(r['name'])
+            setattr(StatefulTestStaffWithProgramAuto, testFunc.__name__, testFunc)
+
+        for r in route_lister.get_route_list(main.post_routes):
+            if '<' in r['template']:
+                continue  # TODO: figure out how to test paths with id segments.
+            testFunc = StatefulTestStaffWithProgramAuto.get_test_function(r['template'], 'POST')
+            testFunc.__name__ = 'test{}'.format(r['name'])
+            setattr(StatefulTestStaffWithProgramAuto, testFunc.__name__, testFunc)
+
 
 class StatefulTestStaffWithProgramCustom(StatefulTestStaffWithProgram):
     """Test specific routes with a certain degree of intelligence."""
@@ -119,3 +160,9 @@ class StatefulTestStaffWithProgramCustom(StatefulTestStaffWithProgram):
         self.assertIn('110TEST', response.body)
         self.assertIn('My First Item', response.body)
         self.assertIn('Acorn City', response.body)
+
+
+StatefulTestStaffWithProgramAuto.build()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_staff.py
+++ b/test/test_staff.py
@@ -19,8 +19,8 @@ APP = TestApp(main.app)
 class LoggedInTest(unittest.TestCase):
 
     def setUp(self):
-        app_engine_test_utils.activate_app_engine_testbed()
-        app_engine_test_utils.clear_ndb_cache()
+        app_engine_test_utils.activate_app_engine_testbed_and_clear_cache()
+
 
     def testStaffHome(self):
         response = APP.get('/room/staff_home')
@@ -32,9 +32,9 @@ class LoggedInTest(unittest.TestCase):
 class StatefulTestNoProgram(unittest.TestCase):
 
     def setUp(self):
-        app_engine_test_utils.activate_app_engine_testbed()
-        app_engine_test_utils.clear_ndb_cache()
-        self.keys = test_models.CreateAll()        
+        app_engine_test_utils.activate_app_engine_testbed_and_clear_cache()
+
+        self.keys = test_models.CreateAll()
                 
     def tearDown(self):
         test_models.DeleteAll(self.keys)
@@ -48,9 +48,9 @@ class StatefulTestNoProgram(unittest.TestCase):
 class StatefulTestCaptain(unittest.TestCase):
 
     def setUp(self):
-        app_engine_test_utils.activate_app_engine_testbed()
-        app_engine_test_utils.clear_ndb_cache()
-        self.keys = test_models.CreateAll()        
+        app_engine_test_utils.activate_app_engine_testbed_and_clear_cache()
+
+        self.keys = test_models.CreateAll()
         s = self.keys['STAFF'].get()
         s.program_selected = '2011 Test'
         s.put()
@@ -69,8 +69,8 @@ class StatefulTestCaptain(unittest.TestCase):
 class StatefulTestStaffWithProgram(unittest.TestCase):
 
     def setUp(self):
-        app_engine_test_utils.activate_app_engine_testbed()
-        app_engine_test_utils.clear_ndb_cache()
+        app_engine_test_utils.activate_app_engine_testbed_and_clear_cache()
+
         self.keys = test_models.CreateAll()
         s = self.keys['STAFF'].get()
         s.program_selected = '2011 Test'

--- a/test/test_wsgi_service.py
+++ b/test/test_wsgi_service.py
@@ -1,10 +1,10 @@
 """Functional tests for WSGI app for Protocol RPC service API."""
 
-import unittest2
+import unittest
 from webtest import TestApp
 from room import wsgi_service
 from test import test_models
-
+import app_engine_test_utils
 app = TestApp(wsgi_service.application)
 
 
@@ -19,8 +19,10 @@ models_and_data = (
 )
 
 
-class BasicCrudTest(unittest2.TestCase):
+class BasicCrudTest(unittest.TestCase):
     def setUp(self):
+        app_engine_test_utils.activate_app_engine_testbed()
+        app_engine_test_utils.clear_ndb_cache()
         self.keys = test_models.CreateAll()
 
     def tearDown(self):
@@ -134,8 +136,10 @@ for name, fields in models_and_data:
     setattr(BasicCrudTest, 'test{}UpdateBadWrongId'.format(name), tstUpdateBadWrongId)
     
     
-class ChoicesTest(unittest2.TestCase):
+class ChoicesTest(unittest.TestCase):
     def setUp(self):
+        app_engine_test_utils.activate_app_engine_testbed()
+        app_engine_test_utils.clear_ndb_cache()
         self.keys = test_models.CreateAll()
 
     def tearDown(self):
@@ -153,8 +157,10 @@ class ChoicesTest(unittest2.TestCase):
         self.assertDictContainsSubset({u'label': u'House of Supply'}, response.json['choice'][0])
         
 
-class BugsTest(unittest2.TestCase):
+class BugsTest(unittest.TestCase):
     def setUp(self):
+        app_engine_test_utils.activate_app_engine_testbed()
+        app_engine_test_utils.clear_ndb_cache()
         self.keys = test_models.CreateAll()
 
     def tearDown(self):
@@ -184,8 +190,10 @@ class BugsTest(unittest2.TestCase):
         self.assertEquals('2011-02-03', response.json['payment_date'])
 
 
-class CustomApiTest(unittest2.TestCase):
+class CustomApiTest(unittest.TestCase):
     def setUp(self):
+        app_engine_test_utils.activate_app_engine_testbed()
+        app_engine_test_utils.clear_ndb_cache()
         self.keys = test_models.CreateAll()
         
     def tearDown(self):
@@ -243,5 +251,3 @@ class CustomApiTest(unittest2.TestCase):
         self.assertEquals(u'Joe Retrieval', response.json['retrieval']['contact'])
         self.assertIn(u'pickup', response.json)
         self.assertEquals(u'Joe Pickup', response.json['pickup']['contact'])
-        
-                

--- a/test/test_wsgi_service.py
+++ b/test/test_wsgi_service.py
@@ -21,8 +21,8 @@ models_and_data = (
 
 class BasicCrudTest(unittest.TestCase):
     def setUp(self):
-        app_engine_test_utils.activate_app_engine_testbed()
-        app_engine_test_utils.clear_ndb_cache()
+        app_engine_test_utils.activate_app_engine_testbed_and_clear_cache()
+
         self.keys = test_models.CreateAll()
 
     def tearDown(self):
@@ -138,8 +138,8 @@ for name, fields in models_and_data:
     
 class ChoicesTest(unittest.TestCase):
     def setUp(self):
-        app_engine_test_utils.activate_app_engine_testbed()
-        app_engine_test_utils.clear_ndb_cache()
+        app_engine_test_utils.activate_app_engine_testbed_and_clear_cache()
+
         self.keys = test_models.CreateAll()
 
     def tearDown(self):
@@ -159,8 +159,8 @@ class ChoicesTest(unittest.TestCase):
 
 class BugsTest(unittest.TestCase):
     def setUp(self):
-        app_engine_test_utils.activate_app_engine_testbed()
-        app_engine_test_utils.clear_ndb_cache()
+        app_engine_test_utils.activate_app_engine_testbed_and_clear_cache()
+
         self.keys = test_models.CreateAll()
 
     def tearDown(self):
@@ -227,8 +227,8 @@ class BugsTest(unittest.TestCase):
         
 class CustomApiTest(unittest.TestCase):
     def setUp(self):
-        app_engine_test_utils.activate_app_engine_testbed()
-        app_engine_test_utils.clear_ndb_cache()
+        app_engine_test_utils.activate_app_engine_testbed_and_clear_cache()
+
         self.keys = test_models.CreateAll()
         
     def tearDown(self):

--- a/test/test_wsgi_service.py
+++ b/test/test_wsgi_service.py
@@ -183,7 +183,42 @@ class BugsTest(unittest2.TestCase):
         self.assertIn(u'payment_date', response.json)
         self.assertEquals('2011-02-03', response.json['payment_date'])
 
+    def testCaptainNoEmail(self):
+        post_json_body = {
+            "name": "Mister Captain",
+            }
+        response = app.post_json('/wsgi_service.captain_create',
+                                 post_json_body,
+                                 status=200,
+                                 headers={'x-rooms-dev-signin-email': 'rebuildingtogether.staff@gmail.com'})
+        self.assertEquals('200 OK', response.status)
+        self.assertIn(u'name', response.json)
+        self.assertEquals('Mister Captain', response.json['name'])
 
+    def testCaptainEmptyEmail(self):
+        post_json_body = {
+            "name": "Mister Captain",
+            "email": ""}
+        response = app.post_json('/wsgi_service.captain_create',
+                                 post_json_body,
+                                 status=200,
+                                 headers={'x-rooms-dev-signin-email': 'rebuildingtogether.staff@gmail.com'})
+        self.assertEquals('200 OK', response.status)
+        self.assertIn(u'name', response.json)
+        self.assertEquals('Mister Captain', response.json['name'])
+
+    def testCaptainLowerEmail(self):
+        post_json_body = {
+            "name": "Mister Captain",
+            "email": "Mister@Captain.com"}
+        response = app.post_json('/wsgi_service.captain_create',
+                                 post_json_body,
+                                 status=200,
+                                 headers={'x-rooms-dev-signin-email': 'rebuildingtogether.staff@gmail.com'})
+        self.assertEquals('200 OK', response.status)
+        self.assertIn(u'email', response.json)
+        self.assertEquals('mister@captain.com', response.json['email'])
+        
 class CustomApiTest(unittest2.TestCase):
     def setUp(self):
         self.keys = test_models.CreateAll()


### PR DESCRIPTION
Two related items:
  - converts tests to unittest and
  - fixes testSiteBudgetExport per issue #308 

Outstanding issues/questions:
1. the payload for the post is hard-coded {'submit': staff.EXPORT_CSV} which is non-ideal. where should this data be instead?
1. do the tests still run for both of you @babybunny and @kate-mills using your desired dev setup? you should be able to run them using nose2 if you like, otherwise you should also be able to call ./virtualenv/bin/python -m unittest discover --verbose. Note however that the test wsgi tests require you to dump /path/to/google-cloud-sdk/platform/google_appengine/lib/protorpc-1.0/ into your PYTHONPATH somehow