### PR TITLE
use query parameter instead of path regex

### DIFF
--- a/gae/main.py
+++ b/gae/main.py
@@ -200,13 +200,13 @@ login_required = routes.PathPrefixRoute('/room', [
   #               name='Example'),
 
 
-  webapp2.Route(r'/site/view/<id:\d+>/',
+  webapp2.Route(r'/site/view',
                 staff.SiteView,
                 name='SiteView'),
   webapp2.Route(r'/site/lookup/<site_number:\w+>',
                 staff.SiteLookup,
                 name='SiteLookup'),
-  webapp2.Route(r'/site/list/<id:\d+>/',  # back compat
+  webapp2.Route(r'/site/list',  # back compat
                 staff.SiteView,
                 name='SiteViewBackCompat'),
   webapp2.Route(r'/site/<id:\d*>',

--- a/gae/room/staff.py
+++ b/gae/room/staff.py
@@ -121,10 +121,21 @@ class CaptainAutocomplete(AutocompleteHandler):
 
 
 class SiteView(StaffHandler):
-  def get(self, id=None):
-    if id:
-      id = int(id)
-      site = ndb.Key(ndb_models.NewSite, id).get()
+  def get(self):
+    if 'id' not in self.request.GET:
+      msg = "{0} url expects an id query parameter".format(self.__class__.__name__)
+      logging.error(msg)
+      self.response.set_status(500)
+      self.response.write(msg)
+      return
+    id = int(self.request.GET['id'])
+    site = ndb.Key(ndb_models.NewSite, id).get()
+    if site is None:
+      msg = "site id {0} was not recognized".format(id)
+      logging.error(msg)
+      self.response.set_status(404)
+      self.response.write(msg)
+      return
     d = dict(
       map_width=common.MAP_WIDTH, map_height=common.MAP_HEIGHT
     )

--- a/test/test_staff.py
+++ b/test/test_staff.py
@@ -7,7 +7,7 @@ from webtest import TestApp
 
 import app_engine_test_utils
 from gae import main
-from gae.room import staff
+from gae.room import staff, ndb_models
 from test import route_lister
 from test import test_models
 
@@ -142,11 +142,13 @@ class StatefulTestStaffWithProgramCustom(StatefulTestStaffWithProgram):
     self.assertIn('Miss Captain', str(response))
 
   def testSiteView(self):
-    response = self._get('/room/site/view?id={:d}'.format(self.keys['SITE'].integer_id()))
-    self.assertEquals('200 OK', response.status)
-    self.assertIn('2011 Test', response.body)
-    self.assertIn('110TEST', response.body)
-    self.assertIn('Miss Captain', response.body)
+    models = ndb_models.NewSite().query()
+    self.assertGreater(models.count(), 0, "No NewSite Test data found")
+    for model in models:
+      response = self._get('/room/site/view?id={:d}'.format(model.key.integer_id()))
+      self.assertEquals('200 OK', response.status)
+      self.assertTrue(str(model.name) in response.body)
+      self.assertTrue(str(model.program) in response.body)
 
   def testOrderView(self):
     response = self._get('/room/order_view/{:d}'.format(self.keys['ORDER'].integer_id()))

--- a/test/test_staff.py
+++ b/test/test_staff.py
@@ -1,7 +1,8 @@
 """Functional tests for staff views."""
 
 import unittest
-
+import path_utils
+path_utils.fix_sys_path()
 from webtest import TestApp
 
 import app_engine_test_utils
@@ -141,7 +142,7 @@ class StatefulTestStaffWithProgramCustom(StatefulTestStaffWithProgram):
     self.assertIn('Miss Captain', str(response))
 
   def testSiteView(self):
-    response = self._get('/room/site/view/{:d}/'.format(self.keys['SITE'].integer_id()))
+    response = self._get('/room/site/view?id={:d}'.format(self.keys['SITE'].integer_id()))
     self.assertEquals('200 OK', response.status)
     self.assertIn('2011 Test', response.body)
     self.assertIn('110TEST', response.body)
@@ -154,12 +155,12 @@ class StatefulTestStaffWithProgramCustom(StatefulTestStaffWithProgram):
     self.assertIn('My First Item', response.body)
     self.assertIn('Acorn City', response.body)
 
-    def testOrderReconcile(self):
-        response = self._get('/room/order_reconcile/{:d}'.format(self.keys['ORDERSHEET'].integer_id()))
-        self.assertEquals('200 OK', response.status)
-        self.assertIn('Being Filled', response.body)
+  def testOrderReconcile(self):
+    response = self._get('/room/order_reconcile/{:d}'.format(self.keys['ORDERSHEET'].integer_id()))
+    self.assertEquals('200 OK', response.status)
+    self.assertIn('Being Filled', response.body)
 
-        
+
 StatefulTestStaffWithProgramAuto.build()
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is to get the conversation started. Using query parameters instead of path regex has a few advantages that I can think of, from needing fewer handlers to improving testability.

NOTE: webapp2.uri_for will work with this change without requiring any changes
NOTE2: If any URLs have been passed around to sites those would cease to work so before merging if we choose to do this we should add some redirects so those links continue to work