### PR TITLE
Issue408 - type is required when creating a sitecaptain 

### DIFF
--- a/gae/js/app/models/sitecaptain.js
+++ b/gae/js/app/models/sitecaptain.js
@@ -4,8 +4,22 @@ define(
         var Model = Backbone.Model.extend({
             // matches first part of method name in @remote.method
             urlRoot: '/cru_api.sitecaptain_',
+            validate: function(attrs, options){
+                this.errorModel.clear();
+
+                if (!attrs.captain){
+                    this.errorModel.set({captain: 'Please select a captain.'})
+                }
+                if (!attrs.type){
+                    this.errorModel.set({type: 'Please select captain type.'})
+                }
+                if (!_.isEmpty(_.compact(this.errorModel.toJSON()))) {
+                    return "Validation errors. Please fix.";
+                }
+
+            }
         });
-        
+
         return Model;
     }
 );

--- a/gae/js/app/views/sitecaptain.js
+++ b/gae/js/app/views/sitecaptain.js
@@ -40,7 +40,7 @@ define(
                 label: "Add Captain"
             }
         ];
-        
+
         var View = Backbone.View.extend({
             el: '#sitecaptain-form-view',
             events: {
@@ -71,12 +71,14 @@ define(
             addCaptain: function() {
                 console.log('add captain ', this);
                 var self = this;
-                this.model.save().then(function() {
-                    // TODO self.model.set('name', 
-                    self.sitecaptains.add(self.model);
-                    self.model = new SiteCaptainModel({site: self.options.site_id});
-                    self.makeForm();
-                    self.render();
+                this.model.save(null, {
+                    'success': function(){
+                        // TODO self.model.set('name',
+                        self.sitecaptains.add(self.model);
+                        self.model = new SiteCaptainModel({site: self.options.site_id});
+                        self.makeForm();
+                        self.render();
+                    }
                 });
             },
             render: function() {


### PR DESCRIPTION
You can check this version out at, https://issue408-dot-rebuildingtogethercaptain-hrd.appspot.com/


The following TypeError was thrown if I tried to create a sitecaptain without a captain and type selected.  That is why I replaced it with the success callback.

Uncaught TypeError: this.model.save(...).then is not a function
    at child.addCaptain (sitecaptain.js:74)
    at HTMLDivElement.dispatch (jquery.js:3)
    at HTMLDivElement.q.handle (jquery.js:3)

