### PR TITLE
issue407 - crash in /cru_api.sitecaptain_create

### DIFF
--- a/gae/js/app/views/sitecaptain.js
+++ b/gae/js/app/views/sitecaptain.js
@@ -76,7 +76,14 @@ define(
                 var self = this;
 
                 var choices = this.form.fields.models.find(function(model){return model.get('name') == 'captain';});
-                var captain_label  = _.findWhere(choices.get('options'), {value: self.model.get('captain')}).label;
+                var captain_label  = function(){
+                    var captain =  _.findWhere(choices.get('options'), {value: self.model.get('captain')});
+                    if(captain){
+                        return captain.label;
+                    }else{
+                        return undefined;
+                    }
+                }();
 
                 this.model.save(null, {
                     'success': function(){


### PR DESCRIPTION
If  a user does not select a sitecaptain, this commit seems to fix the following browser error: 
     _Uncaught TypeError: Cannot read property 'label' of undefined_

You can check this out here:
https://issue407-dot-rebuildingtogethercaptain-hrd.appspot.com/room/staff_home
