### PR TITLE
Issue_303 - delivery and retrieval and pickup dates should be forced 

### DIFF
--- a/gae/js/app/views/order_flow.js
+++ b/gae/js/app/views/order_flow.js
@@ -79,14 +79,14 @@ define(
                 name: 'dropoff_date',
                 label: 'Delivery date (Mon-Fri only)',
                 control: "datepicker",
-                options: {format: "yyyy-mm-dd"},
+                options: {format: "yyyy-mm-dd", startDate: "0d"},
                 required: true
             },
             {
                 name: 'retrieval_date',
                 label: 'Retrieval Date (Mon-Fri only)',
                 control: "datepicker",
-                options: {format: "yyyy-mm-dd"},
+                options: {format: "yyyy-mm-dd", startDate: "0d"},
                 required: true
             },
         ].concat(basic_logistics_fields);

--- a/gae/js/app/views/order_flow.js
+++ b/gae/js/app/views/order_flow.js
@@ -52,7 +52,7 @@ define(
                 name: 'delivery_date',
                 label: 'Delivery date (Mon-Fri only)',
                 control: "datepicker",
-                options: {format: "yyyy-mm-dd", startDate: "0d"},
+                options: {format: "yyyy-mm-dd", startDate: "0d", daysOfWeekDisabled: "06"},
                 required: true
             },
         ].concat(basic_logistics_fields);
@@ -62,7 +62,7 @@ define(
                 name: 'pickup_date',
                 label: 'Pickup date (Mon-Fri only)',
                 control: "datepicker",
-                options: {format: "yyyy-mm-dd", startDate: "+2d"},
+                options: {format: "yyyy-mm-dd", startDate: "+2d",  daysOfWeekDisabled: "06"},
                 required: true
             },
             {
@@ -79,14 +79,14 @@ define(
                 name: 'dropoff_date',
                 label: 'Delivery date (Mon-Fri only)',
                 control: "datepicker",
-                options: {format: "yyyy-mm-dd", startDate: "0d"},
+                options: {format: "yyyy-mm-dd", startDate: "0d",  daysOfWeekDisabled: "06"},
                 required: true
             },
             {
                 name: 'retrieval_date',
                 label: 'Retrieval Date (Mon-Fri only)',
                 control: "datepicker",
-                options: {format: "yyyy-mm-dd", startDate: "0d"},
+                options: {format: "yyyy-mm-dd", startDate: "0d",  daysOfWeekDisabled: "06"},
                 required: true
             },
         ].concat(basic_logistics_fields);

--- a/gae/js/app/views/order_flow.js
+++ b/gae/js/app/views/order_flow.js
@@ -70,6 +70,7 @@ define(
                 label: '(Optional) Return date for durable equipment',
                 control: "datepicker",
                 options: {format: "yyyy-mm-dd"},
+                required: true
             },
         ].concat(basic_logistics_fields);
 
@@ -79,12 +80,14 @@ define(
                 label: 'Delivery date (Mon-Fri only)',
                 control: "datepicker",
                 options: {format: "yyyy-mm-dd"},
+                required: true
             },
             {
                 name: 'retrieval_date',
                 label: 'Retrieval Date (Mon-Fri only)',
                 control: "datepicker",
                 options: {format: "yyyy-mm-dd"},
+                required: true
             },
         ].concat(basic_logistics_fields);
 
@@ -92,13 +95,13 @@ define(
             initialize: function(site_id, order_id) {
                 var self = this;
                 this.order_id = order_id;
-                
+
                 var site = new Site({id: site_id});
                 site.fetch().then(function() {self.site = site; self.render()});
 
                 this.logistics_dates = new LogisticsDates(site_id);
                 this.logistics_dates.fetch();
-                
+
                 this.sitecaptains = new SiteCaptains(site_id);
                 this.sitecaptains.fetch();
 
@@ -110,7 +113,7 @@ define(
                         self.order_items = new OrderItems(order_full.get('order_items'));
                         self.listenTo(self.order_items, 'change add', self.renderStep2);
                         self.listenTo(self.order, 'change', self.renderStep2);
-                        
+
                         if (order_full.has('delivery')) {
                             self.delivery = new Backbone.Model(order_full.get('delivery'));
                         }
@@ -125,7 +128,7 @@ define(
                         ofd.fetch().then(function() {
                             self.order_form_detail = ofd;
                             self.renderStep2();
-                        });                    
+                        });
                     });
                 } else {
                     this.order_full = new OrderFull();
@@ -153,7 +156,7 @@ define(
                 'click #order-proceed-no-logistics': 'save',
             },
             savenotes: function(e) {
-                this.order.set('notes', e.target.value);                
+                this.order.set('notes', e.target.value);
             },
             changeQuantity: function(e) {
                 var oi = this.order_items.get(parseInt(e.target.name));
@@ -281,7 +284,7 @@ define(
             },
             renderStep2: function() {
                 console.log('step 2');
-                var self = this;                
+                var self = this;
                 if (!this.site) {
                     return this;  // loading
                 }
@@ -320,12 +323,12 @@ define(
                 });
                 this.$el.html(t);
                 return this;
-            },           
+            },
             renderStep1: function() {  // step 1, render the choose order form screen.
                 var self = this;
-                if (!this.site) {  
+                if (!this.site) {
                     console.log('waiting for site');
-                    return this;  // loading 
+                    return this;  // loading
                 }
                 if (!this.order_full) {
                     console.log('waiting for order_full');
@@ -335,7 +338,7 @@ define(
                     console.log('waiting for order_forms');
                     return this;  // loading
                 }
-                
+
                 var t = this.choose_form_template({
                     s: this.order.attributes,
                     site: this.site,

--- a/gae/js/app/views/order_flow.js
+++ b/gae/js/app/views/order_flow.js
@@ -52,7 +52,7 @@ define(
                 name: 'delivery_date',
                 label: 'Delivery date (Mon-Fri only)',
                 control: "datepicker",
-                options: {format: "yyyy-mm-dd"},
+                options: {format: "yyyy-mm-dd", startDate: "0d"},
                 required: true
             },
         ].concat(basic_logistics_fields);

--- a/gae/js/app/views/order_flow.js
+++ b/gae/js/app/views/order_flow.js
@@ -266,6 +266,7 @@ define(
                 this.logistics_form = new Backform.Form({
                     model: model,
                     fields: fields,
+                    showRequiredAsAsterisk: true,
                     events: {
                         'submit': function(e) {
                             e.preventDefault();
@@ -275,7 +276,7 @@ define(
                 });
                 this.listenTo(this.logistics_form, 'submit', this.save);
                 this.logistics_form.setElement(this.$el.find('#order-logistics-form'));
-                this.logistics_form.render();
+                this.logistics_form.render().$el.find('label.control-label:contains("*")').addClass('required');
                 return this;
             },
             render: function() {

--- a/gae/js/app/views/order_flow.js
+++ b/gae/js/app/views/order_flow.js
@@ -62,14 +62,14 @@ define(
                 name: 'pickup_date',
                 label: 'Pickup date (Mon-Fri only)',
                 control: "datepicker",
-                options: {format: "yyyy-mm-dd"},
+                options: {format: "yyyy-mm-dd", startDate: "+2d"},
                 required: true
             },
             {
                 name: 'return_date',
                 label: '(Optional) Return date for durable equipment',
                 control: "datepicker",
-                options: {format: "yyyy-mm-dd"},
+                options: {format: "yyyy-mm-dd", startDate: "+2d"},
                 required: true
             },
         ].concat(basic_logistics_fields);


### PR DESCRIPTION
Summary:
    All order_flow dates are forced.
    All order_flow past dates are disabled (grayed out) 
    In most cases, the current date is first available.
         M-F only fields (weekends are disabled)
         pickup_fields 1st availability is 2 days after order entry.
    No end date limits.
    
Check this version out here:  https://issue-303-dot-rebuildingtogethercaptain-hrd.appspot.com
