### PR TITLE
remove verbose_options from ndb_models classes #471

### DIFF
--- a/gae/js/app/views/checkrequest.js
+++ b/gae/js/app/views/checkrequest.js
@@ -52,7 +52,8 @@ define(
             },
             {
                 name: "name",
-                label: "Payable To",
+                label: "Name",
+                helpMessage: "Payable To",
                 control: "input",
                 required: true
             },
@@ -87,18 +88,20 @@ define(
 
             {
                 name: "address",
-                label: "Payee Address",
+                label: "Address",
+                helpMessage: "Payee Address",
                 control: "textarea"
             },
             {
                 name: "tax_id",
-                label: "Payee Tax ID",
+                label: "Tax ID",
                 control: "input",
-                helpMessage: "We'll notify you if we still need this information to process the check"
+                helpMessage: "Payee Tax ID  (We'll notify you if we still need this information to process the check)"
             },
             {
                 name: "form_of_business",
-                label: "Payee Business Type",
+                label: "Form of Business",
+                helpMessage: "Payee Business Type",
                 control: "select",
                 options: [
                     {label: "Corporation", value: "Corporation"},

--- a/gae/js/app/views/inkinddonation.js
+++ b/gae/js/app/views/inkinddonation.js
@@ -64,13 +64,15 @@ define(
             },
             {
                 name: "labor_amount",
-                label: "Labor Value ($)",
+                label: "Labor Amount",
+                helpMessage: "Labor Value ($)",
                 control: "input",
                 value: 0.0,
             },
             {
                 name: "materials_amount",
-                label: "Materials Value ($)",
+                label: "Materials Amount",
+                helpMessage: "Materials Value ($)",
                 control: "input",
                 value: 0.0
             },

--- a/gae/js/app/views/order_flow.js
+++ b/gae/js/app/views/order_flow.js
@@ -140,22 +140,27 @@ define(
         borrow_flow.assign_help('notes', "Instructions for warehouse staff");
         borrow_flow.fields = borrow_flow.get_fields();
 
-        var retrieval_fields = [
+        var retrieval_flow = Fields([
             {
                 name: 'dropoff_date',
-                label: 'Delivery date (Mon-Fri only)',
+                label: 'Dropoff Date',
+                helpMessage: 'Delivery date (Mon-Fri only)',
                 control: "datepicker",
                 options: {format: "yyyy-mm-dd", startDate: "0d",  daysOfWeekDisabled: "06"},
                 required: true
             },
             {
                 name: 'retrieval_date',
-                label: 'Retrieval Date (Mon-Fri only)',
+                label: 'Retrieval Date',
+                helpMessage: 'Retrieval Date (Mon-Fri only)',
                 control: "datepicker",
                 options: {format: "yyyy-mm-dd", startDate: "0d",  daysOfWeekDisabled: "06"},
                 required: true
             },
-        ].concat(basic_logistics_fields);
+        ]);
+        retrieval_flow.assign_help('contact', "Contact person (who will accept delivery)");
+        retrieval_flow.assign_help('notes', "Instructions for delivery person");
+        retrieval_flow.fields = retrieval_flow.get_fields();
 
         var OrderFlowView = Backbone.View.extend({
             initialize: function(site_id, order_id) {
@@ -331,7 +336,7 @@ define(
                     this.retrieval = new Backbone.Model();
                 }
                 this.order_full.set('retrieval', this.retrieval.attributes);
-                this.renderLogistics(retrieval_fields, "Drop-off and Retrieval", this.retrieval);
+                this.renderLogistics(retrieval_flow.fields, "Drop-off and Retrieval", this.retrieval);
             },
             renderLogistics: function(fields, logistics_words, model) {
                 console.log('step 3');

--- a/gae/js/app/views/order_flow.js
+++ b/gae/js/app/views/order_flow.js
@@ -101,9 +101,10 @@ define(
             {
                 name: 'return_date',
                 label: 'Return Date',
-                helpMessage: '(Optional) Return date for durable equipment',
+                helpMessage: 'Return date for durable equipment',
                 control: "datepicker",
-                options: {format: "yyyy-mm-dd", startDate: "+2d"}
+                options: {format: "yyyy-mm-dd", startDate: "+2d"},
+                required: true
             },
         ]);
         borrow_flow.assign_help('contact', "Contact person (who will pick up)");

--- a/gae/js/app/views/order_flow.js
+++ b/gae/js/app/views/order_flow.js
@@ -47,16 +47,55 @@ define(
                 label: "Choose these options and complete order"
             },
         ];
+        function Fields (additional_fields){
+            return {
+                logistics_fields: [
+                    {
+                        name: "contact",
+                        label: "Contact",
+                        control: "input"
+                    },
+                    {
+                        name: "contact_phone",
+                        label: "Contact Phone",
+                        control: "input",
+                    },
+                    ].concat(additional_fields).concat([
+                    {
+                        name: "notes",
+                        label: "Notes",
+                        control: "textarea"
+                    },
+                    {
+                        name: "submit",
+                        control: "button",
+                        extraClasses: ['btn-primary'],
+                        label: "Choose these options and complete order"
+                    },
+                ]),
+                get_fields: function(){
+                    return this.logistics_fields;
+                },
+                assign_help: function(target_name, helpMessage){
+                    var field =  _.where(this.logistics_fields, {name: target_name})[0];
+                    field.helpMessage = helpMessage;
+                }
+            };
+        }
 
-        var delivery_fields = [
+        var delivery_flow = Fields([
             {
                 name: 'delivery_date',
-                label: 'Delivery date (Mon-Fri only)',
+                label: 'Delivery Date',
+                helpMessage: 'Delivery Date (Mon-Fri only)',
                 control: "datepicker",
                 options: {format: "yyyy-mm-dd", startDate: "0d", daysOfWeekDisabled: "06"},
                 required: true
             },
-        ].concat(basic_logistics_fields);
+        ]);
+        delivery_flow.assign_help('contact', "Contact person (who will accept delivery)");
+        delivery_flow.assign_help('notes', "Instructions for the delivery person.");
+        delivery_flow.fields = delivery_flow.get_fields();
 
         var pickup_fields = [
             {
@@ -84,7 +123,7 @@ define(
                 required: true
             },
         ].concat(basic_logistics_fields);
-        
+
         var retrieval_fields = [
             {
                 name: 'dropoff_date',
@@ -255,7 +294,7 @@ define(
                     this.delivery = new Backbone.Model();
                 }
                 this.order_full.set('delivery', this.delivery.attributes);
-                this.renderLogistics(delivery_fields, "Delivery", this.delivery);
+                this.renderLogistics(delivery_flow.fields, "Delivery", this.delivery);
             },
             renderPickup: function() {
                 if (!this.pickup) {

--- a/gae/js/app/views/order_flow.js
+++ b/gae/js/app/views/order_flow.js
@@ -84,13 +84,6 @@ define(
                 options: {format: "yyyy-mm-dd", startDate: "+2d",  daysOfWeekDisabled: "06"},
                 required: true
             },
-            {
-                name: 'return_date',
-                label: 'Return Date',
-                helpMessage: '(Optional) Return date for durable equipment',
-                control: "datepicker",
-                options: {format: "yyyy-mm-dd", startDate: "+2d",  daysOfWeekDisabled: "06"},
-            },
         ]);
         pickup_flow.assign_help('contact', "Contact person (who will pick up)");
         pickup_flow.assign_help('notes', "Instructions for warehouse staff");

--- a/gae/js/app/views/order_flow.js
+++ b/gae/js/app/views/order_flow.js
@@ -27,7 +27,7 @@ define(
 
         function Fields (additional_fields){
             return {
-                logistics_fields: [
+                logistics_fields: additional_fields.concat([
                     {
                         name: "contact",
                         label: "Contact",
@@ -38,7 +38,6 @@ define(
                         label: "Contact Phone",
                         control: "input",
                     },
-                    ].concat(additional_fields).concat([
                     {
                         name: "notes",
                         label: "Notes",

--- a/gae/js/app/views/order_flow.js
+++ b/gae/js/app/views/order_flow.js
@@ -24,29 +24,7 @@ define(
              OrderFormOverview, OrderItems, Order, Site, OrderFormDetail, OrderFull,
              choose_form_template, button_template, select_items_template,
              logistics_template) {
-        var basic_logistics_fields = [
-            {
-                name: "contact",
-                label: "Contact person (who will be present)",
-                control: "input",
-            },
-            {
-                name: "contact_phone",
-                label: "Contact phone",
-                control: "input",
-            },
-            {
-                name: "notes",
-                label: "Instructions for delivery person",
-                control: "textarea"
-            },
-            {
-                name: "submit",
-                control: "button",
-                extraClasses: ['btn-primary'],
-                label: "Choose these options and complete order"
-            },
-        ];
+
         function Fields (additional_fields){
             return {
                 logistics_fields: [

--- a/gae/js/app/views/order_flow.js
+++ b/gae/js/app/views/order_flow.js
@@ -119,22 +119,26 @@ define(
         pickup_flow.fields = pickup_flow.get_fields();
 
 
-        var borrow_fields = [
+        var borrow_flow = Fields([
             {
                 name: 'borrow_date',
-                label: 'Borrow date (Mon-Fri only)',
+                label: 'Borrow Date',
+                helpMessage: 'Borrow Date (Mon-Fri only)',
                 control: "datepicker",
                 options: {format: "yyyy-mm-dd", startDate: "+2d",  daysOfWeekDisabled: "06"},
                 required: true
             },
             {
                 name: 'return_date',
-                label: 'Return date for durable equipment',
+                label: 'Return Date',
+                helpMessage: '(Optional) Return date for durable equipment',
                 control: "datepicker",
-                options: {format: "yyyy-mm-dd", startDate: "+2d"},
-                required: true
+                options: {format: "yyyy-mm-dd", startDate: "+2d"}
             },
-        ].concat(basic_logistics_fields);
+        ]);
+        borrow_flow.assign_help('contact', "Contact person (who will pick up)");
+        borrow_flow.assign_help('notes', "Instructions for warehouse staff");
+        borrow_flow.fields = borrow_flow.get_fields();
 
         var retrieval_fields = [
             {
@@ -320,7 +324,7 @@ define(
                     this.borrow = new Backbone.Model();
                 }
                 this.order_full.set('borrow', this.borrow.attributes);
-                this.renderLogistics(borrow_fields, "Borrow and Return", this.borrow);
+                this.renderLogistics(borrow_flow.fields, "Borrow and Return", this.borrow);
             },
             renderRetrieval: function() {
                 if (!this.retrieval) {

--- a/gae/js/app/views/order_flow.js
+++ b/gae/js/app/views/order_flow.js
@@ -97,15 +97,27 @@ define(
         delivery_flow.assign_help('notes', "Instructions for the delivery person.");
         delivery_flow.fields = delivery_flow.get_fields();
 
-        var pickup_fields = [
+        var pickup_flow = Fields([
             {
                 name: 'pickup_date',
-                label: 'Pickup date (Mon-Fri only)',
+                label: 'Pickup Date',
+                helpMessage: 'Pickup date (Mon-Fri only)',
                 control: "datepicker",
                 options: {format: "yyyy-mm-dd", startDate: "+2d",  daysOfWeekDisabled: "06"},
                 required: true
             },
-        ].concat(basic_logistics_fields);
+            {
+                name: 'return_date',
+                label: 'Return Date',
+                helpMessage: '(Optional) Return date for durable equipment',
+                control: "datepicker",
+                options: {format: "yyyy-mm-dd", startDate: "+2d",  daysOfWeekDisabled: "06"},
+            },
+        ]);
+        pickup_flow.assign_help('contact', "Contact person (who will pick up)");
+        pickup_flow.assign_help('notes', "Instructions for warehouse staff");
+        pickup_flow.fields = pickup_flow.get_fields();
+
 
         var borrow_fields = [
             {
@@ -301,7 +313,7 @@ define(
                     this.pickup = new Backbone.Model();
                 }
                 this.order_full.set('pickup', this.pickup.attributes);
-                this.renderLogistics(pickup_fields, "Pickup", this.pickup);
+                this.renderLogistics(pickup_flow.fields, "Pickup", this.pickup);
             },
             renderBorrow: function() {
                 if (!this.borrow) {

--- a/gae/js/app/views/ordersheet.js
+++ b/gae/js/app/views/ordersheet.js
@@ -66,6 +66,8 @@ define(
 		            room_model_module: SupplierChoices,
                 helpMessage: "Default Supplier, used if Item\'s supplier is not set."
             },
+            {   control: "spacer"
+            },
             {
                 name: "order_form_helper",
                 control: "help",

--- a/gae/js/app/views/ordersheet.js
+++ b/gae/js/app/views/ordersheet.js
@@ -64,7 +64,12 @@ define(
                 label: "Default supplier",
                 control: ModelSelectControl,
 		            room_model_module: SupplierChoices,
-                helpMessage: "Default Supplier, used if Item's supplier is not set."
+                helpMessage: "Default Supplier, used if Item\'s supplier is not set."
+            },
+            {
+                name: "order_form_helper",
+                control: "help",
+                label: "Choose one of the next four."
             },
             {
                 name: "delivery_options",

--- a/gae/js/app/views/site.js
+++ b/gae/js/app/views/site.js
@@ -30,13 +30,15 @@ define(
                 name: "name",
                 label: "Recipient Name",
                 control: "input",
-                type: "text"
+                type: "text",
+                helpMessage: "Recipient Name"
             },
             {
                 name: "applicant",
                 label: "Applicant Contact",
                 control: "input",
-                type: "text"
+                type: "text",
+                helpMessage: "Applicant Contact"
             },
             {
                 name: "applicant_home_phone",

--- a/gae/js/app/views/vendorreceipt.js
+++ b/gae/js/app/views/vendorreceipt.js
@@ -42,7 +42,8 @@ define(
             },
             {
                 name: "amount",
-                label: "Purchase Amount ($)",
+                label: "Amount",
+                helpText: "Purchase Amount ($)",
                 control: "input"
             },
             {

--- a/gae/room/ndb_models.py
+++ b/gae/room/ndb_models.py
@@ -446,38 +446,13 @@ class UploadedDocument(ndb.Model):
 
 class SiteAttachments(ndb.Model):
   one = ndb.KeyProperty(kind=UploadedDocument,
-                        name='Planned Scope of Work',
-                        verbose_name="This is RTP's rough scope of work recommendation for the Construction Captain. "
-                                     "This should be reviewed by the Captain prior to first site visit. Captain is to "
-                                     "take this scope and adjust it according to what they can realistically commit to."
-                                     "<br><br>This document will be on ROOMs prior to Captain Kick off.")
+                        name='Planned Scope of Work')
   two = ndb.KeyProperty(kind=UploadedDocument,
-                        name='Signed Scope of Work',
-                        verbose_name="It's crucial that Captains have their site owners sign-off on the scope of work "
-                                     "prior to any work starting. Captains, after you have walked the property "
-                                     "and assessed priorities, please write or type out the scope, review it with "
-                                     "site owner, and have them sign up top on the scope of work form to show "
-                                     "approval. Please leave them a copy and upload a scanned version here. This is "
-                                     "RTP's way of confirming everyone is in agreement. Upload your scanned signed "
-                                     "scope of work here.<br><br>Due March 26th for 2018 National Rebuilding Day")
+                        name='Signed Scope of Work')
   three = ndb.KeyProperty(kind=UploadedDocument,
-                          name='Submitted Scope of Work',
-                          verbose_name="Since signed scopes are usually in a PDF format, we also need a typed out "
-                                       "version uploaded. This is important for RTP's reporting purposes. Captains "
-                                       "please do your best to also upload a submitted typed scope of work (doc). If "
-                                       "only a PDF signed scoped is uploaded, RTP staff will type this info into a "
-                                       "submitted scope of work for the Site.<br><br>Also Due March 26th for 2018 "
-                                       "National Rebuilding Day.")
+                          name='Submitted Scope of Work')
   four = ndb.KeyProperty(kind=UploadedDocument,
-                         name='Fully Executed Signed Scope of Work',
-                         verbose_name="On National Rebuilding Day (or within a few weeks after), please omplete all "
-                                      "\"primary tasks\" on the scope of work, review the completion with the site "
-                                      "owner, and have them sign at the bottom of the scope of work form (feel free "
-                                      "to use the exact same document that was signed before work started). Please "
-                                      "upload \"Fully Executed Signed Scope of Work\" here. This is RTP's way of "
-                                      "recognizing that the Scope of work is complete and the site owner is in "
-                                      "agreement. This is the final document needed.<br><br>Due May 23rd for 2018 "
-                                      "National Rebuilding Today.")
+                         name='Fully Executed Signed Scope of Work')
 
   def set_attachment_by_property_name(self, property_name, document_key):
     for prop in self.get_ordered_properties():
@@ -502,19 +477,17 @@ class SiteAttachments(ndb.Model):
         site_id=site_id,
         attachments_id=self.key.integer_id(),
         attached_file=attached_file,
-        name=property._name,
-        verbose_name=property._verbose_name
+        name=property._name
       ))
     return attachments
 
 class SiteAttachmentHandlerData(object):
 
-  def __init__(self, site_id, attachments_id, attached_file, name, verbose_name):
+  def __init__(self, site_id, attachments_id, attached_file, name):
     self.site_id = site_id
     self.attachments_id = attachments_id
     self.attached_file = attached_file
     self.name = name
-    self.verbose_name = verbose_name
     self.upload_uri = None
     self.remove_uri = None
     self.filename = attached_file.filename if attached_file else None

--- a/gae/room/ndb_models.py
+++ b/gae/room/ndb_models.py
@@ -1320,7 +1320,6 @@ class Expense(SearchableModel):
   program_key = ndb.KeyProperty(kind=Program)
   date = ndb.DateProperty()
   amount = ndb.FloatProperty()
-  amount.verbose_name = 'Purchase Amount ($)'
   description = ndb.TextProperty()
   state = ndb.StringProperty()
   last_editor = ndb.UserProperty()

--- a/gae/room/ndb_models.py
+++ b/gae/room/ndb_models.py
@@ -1169,22 +1169,15 @@ class CheckRequest(SearchableModel):
   program_key = ndb.KeyProperty(kind=Program)
   payment_date = ndb.DateProperty()
   labor_amount = ndb.FloatProperty(default=0.0)
-  labor_amount.verbose_name = 'Labor Amount ($)'
   materials_amount = ndb.FloatProperty(default=0.0)
-  materials_amount.verbose_name = 'Materials Amount ($)'
   food_amount = ndb.FloatProperty(default=0.0)
-  food_amount.verbose_name = 'Food Amount ($)'
   description = ndb.TextProperty()
   name = ndb.StringProperty()
-  name.verbose_name = 'Payable To'
   address = ndb.TextProperty()
-  address.verbose_name = "Payee Address"
   tax_id = ndb.StringProperty()
-  tax_id.verbose_name = "Payee Tax ID"
   form_of_business = ndb.StringProperty(
     choices=('Corporation', 'Partnership', 'Sole Proprietor',
              'Don\'t Know'))
-  form_of_business.verbose_name = "Payee Business Type"
   state = ndb.StringProperty()
   last_editor = ndb.UserProperty(auto_current_user=True)
   modified = ndb.DateTimeProperty(auto_now=True)

--- a/gae/room/ndb_models.py
+++ b/gae/room/ndb_models.py
@@ -1268,9 +1268,7 @@ class StaffTime(SearchableModel):
   program_key = ndb.KeyProperty(kind=Program)
   state = ndb.StringProperty()
   hours = ndb.FloatProperty(default=0.0)
-  hours.verbose_name = 'Hours'
   miles = ndb.FloatProperty(default=0.0)
-  miles.verbose_name = 'Miles'
   activity_date = ndb.DateProperty()
   description = ndb.TextProperty()
   last_editor = ndb.UserProperty(auto_current_user=True)

--- a/gae/room/ndb_models.py
+++ b/gae/room/ndb_models.py
@@ -1033,13 +1033,9 @@ class Delivery(SearchableModel):
   """Delivery to a site (no retrieval)."""
   site = ndb.KeyProperty(kind=NewSite, required=True)
   delivery_date = ndb.StringProperty()
-  delivery_date.verbose_name = 'Delivery Date (Mon-Fri only)'
   contact = ndb.StringProperty()
-  contact.verbose_name = "Contact person (who will accept delivery)"
   contact_phone = ndb.StringProperty()
   notes = ndb.TextProperty()
-  notes.verbose_name = (
-    'Instructions for delivery person')
 
 
 class OrderDelivery(SearchableModel):

--- a/gae/room/ndb_models.py
+++ b/gae/room/ndb_models.py
@@ -1064,15 +1064,10 @@ class Borrow(SearchableModel):
   """Pick up from RTP warehouse."""
   site = ndb.KeyProperty(kind=NewSite, required=True)
   borrow_date = ndb.StringProperty()
-  borrow_date.verbose_name = 'Borrow Date (Mon-Fri only)'
   return_date = ndb.StringProperty()
-  return_date.verbose_name = '(Optional) Return date for durable equipment'
   contact = ndb.StringProperty()
-  contact.verbose_name = "Contact person (who will pick up)"
   contact_phone = ndb.StringProperty()
   notes = ndb.TextProperty()
-  notes.verbose_name = (
-    'Instructions for warehouse staff')
 
 
 class OrderBorrow(SearchableModel):

--- a/gae/room/ndb_models.py
+++ b/gae/room/ndb_models.py
@@ -1233,13 +1233,8 @@ class InKindDonation(SearchableModel):
   donor = ndb.StringProperty()
   donor_phone = ndb.StringProperty()
   donor_info = ndb.TextProperty()
-  donor_info.verbose_name = (
-    'Include as much of the following donor information as possible:'
-    ' donor name, company, address, phone, email.')
   labor_amount = ndb.FloatProperty(default=0.0)
-  labor_amount.verbose_name = 'Labor Value ($)'
   materials_amount = ndb.FloatProperty(default=0.0)
-  materials_amount.verbose_name = 'Materials Value ($)'
   description = ndb.TextProperty()
   budget = ndb.StringProperty(choices=('Normal', 'Roofing'), default='Normal')
   state = ndb.StringProperty()

--- a/gae/room/ndb_models.py
+++ b/gae/room/ndb_models.py
@@ -1048,15 +1048,10 @@ class Pickup(SearchableModel):
   """Pick up from RTP warehouse."""
   site = ndb.KeyProperty(kind=NewSite, required=True)
   pickup_date = ndb.StringProperty()
-  pickup_date.verbose_name = 'Pickup Date (Mon-Fri only)'
   return_date = ndb.StringProperty()
-  return_date.verbose_name = '(Optional) Return date for durable equipment'
   contact = ndb.StringProperty()
-  contact.verbose_name = "Contact person (who will pick up)"
   contact_phone = ndb.StringProperty()
   notes = ndb.TextProperty()
-  notes.verbose_name = (
-    'Instructions for warehouse staff')
 
 
 class OrderPickup(SearchableModel):

--- a/gae/room/ndb_models.py
+++ b/gae/room/ndb_models.py
@@ -548,9 +548,7 @@ class NewSite(SearchableModel):
   program = ndb.StringProperty()  # reference
   program_key = ndb.KeyProperty(kind=Program)  # TODO: Set to required after migration
   name = ndb.StringProperty()  # "Belle Haven"
-  name.verbose_name = 'Recipient Name'
   applicant = ndb.StringProperty()
-  applicant.verbose_name = 'Applicant Contact'
   applicant_home_phone = ndb.StringProperty()
   applicant_work_phone = ndb.StringProperty()
   applicant_mobile_phone = ndb.StringProperty()
@@ -564,7 +562,6 @@ class NewSite(SearchableModel):
   scope_of_work = ndb.TextProperty()
   sponsor = ndb.StringProperty()
   street_number = ndb.StringProperty()
-  street_number.verbose_name = "Street Address"
   city_state_zip = ndb.StringProperty()
   budget = ndb.IntegerProperty(default=0)
   attachments = ndb.KeyProperty(kind=SiteAttachments)

--- a/gae/room/ndb_models.py
+++ b/gae/room/ndb_models.py
@@ -1080,15 +1080,10 @@ class Retrieval(SearchableModel):
   """Delivery and retrieval to and from a site."""
   site = ndb.KeyProperty(kind=NewSite, required=True)
   dropoff_date = ndb.StringProperty()
-  dropoff_date.verbose_name = 'Delivery Date (Mon-Fri only)'
   retrieval_date = ndb.StringProperty()
-  retrieval_date.verbose_name = 'Retrieval Date (Mon-Fri only)'
   contact = ndb.StringProperty()
-  contact.verbose_name = "Contact person (who will accept delivery)"
   contact_phone = ndb.StringProperty()
   notes = ndb.TextProperty()
-  notes.verbose_name = (
-    'Instructions for delivery person')
 
 
 class OrderRetrieval(SearchableModel):

--- a/gae/room/ndb_models.py
+++ b/gae/room/ndb_models.py
@@ -355,27 +355,14 @@ class OrderSheet(SearchableModel):
   supports_extra_name_on_order = ndb.BooleanProperty(default=False)
   supports_internal_invoice = ndb.BooleanProperty(default=False)
   code = ndb.StringProperty()
-  code.verbose_name = 'Three-letter code like LUM for Lumber'
   instructions = ndb.TextProperty(default='')
-  instructions.verbose_name = (
-    'Instructions to Captain, appears on order form')
   logistics_instructions = ndb.TextProperty(default='')
-  logistics_instructions.verbose_name = (
-    'Instructions to Captain, appears on logistics form')
   default_supplier = ndb.KeyProperty(kind=Supplier)
-  default_supplier.verbose_name = (
-    'Default Supplier, used if Item\'s supplier is not set.')
-  # Choose one of the next three.
+  # Choose one of the next four.
   delivery_options = ndb.StringProperty(choices=['Yes', 'No'], default='No')
-  delivery_options.verbose_name = ('Allow Captain to select Delivery to site')
   pickup_options = ndb.StringProperty(choices=['Yes', 'No'], default='No')
-  pickup_options.verbose_name = (
-    'Allow Captain to select Pick-up from RTP warehouse')
   borrow_options = ndb.StringProperty(choices=['Yes', 'No'], default='No')
   retrieval_options = ndb.StringProperty(choices=['Yes', 'No'], default='No')
-  retrieval_options.verbose_name = ('Drop-off and retrieval (like debris box)'
-                                    '  Note: do not set this with either'
-                                    ' delivery or pick-up')
 
   def __unicode__(self):
     return '%s' % (self.name)
@@ -1006,7 +993,7 @@ class OrderItem(SearchableModel):
   name = ndb.StringProperty(default="")
   # no default because it's not present for all objects, yet.
   unit_cost = ndb.FloatProperty()
-  
+
   def FloatQuantity(self):
     """Returns quantity as a float."""
     if self.quantity:

--- a/gae/room/ndb_models.py
+++ b/gae/room/ndb_models.py
@@ -1202,7 +1202,6 @@ class VendorReceipt(SearchableModel):
   vendor = ndb.StringProperty()
   supplier = ndb.KeyProperty(kind=Supplier)
   amount = ndb.FloatProperty()
-  amount.verbose_name = 'Purchase Amount ($)'
   description = ndb.TextProperty()
   state = ndb.StringProperty()
   last_editor = ndb.UserProperty()

--- a/gae/room/templates/site_attachments.html
+++ b/gae/room/templates/site_attachments.html
@@ -1,9 +1,48 @@
 <table class="site">
   <tbody>
     {% for a in attachments %}
+
       <h3> {{ a.name }} </h3>
       <div class="panel">
-        <p class="small"> {{ a.verbose_name }} </p>
+
+          {% if a.name == "Planned Scope of Work" %}
+              <p class="small">This is RTP's rough scope of work recommendation for the Construction Captain.
+                            This should be reviewed by the Captain prior to first site visit. Captain is to
+                            take this scope and adjust it according to what they can realistically commit to.
+                            <br><br>This document will be on ROOMs prior to Captain Kick off.</p>
+
+          {% elif a.name == "Signed Scope of Work" %}
+              <p class="small">It's crucial that Captains have their site owners sign-off on the scope of work
+                            prior to any work starting. Captains, after you have walked the property
+                            and assessed priorities, please write or type out the scope, review it with
+                            site owner, and have them sign up top on the scope of work form to show
+                            approval. Please leave them a copy and upload a scanned version here. This is
+                            RTP's way of confirming everyone is in agreement. Upload your scanned signed
+                            scope of work here.
+                            <br><br>Due March 26th for 2018 National Rebuilding Day.</p>
+
+          {% elif a.name == "Submitted Scope of Work" %}
+              <p class="small">Since signed scopes are usually in a PDF format, we also need a typed out
+                          version uploaded. This is important for RTP's reporting purposes.
+                          Captains please do your best to also upload a submitted typed scope of
+                          work (doc). If only a PDF signed scoped is uploaded, RTP staff will type
+                          this info into a submitted scope of work for the Site.
+                          <br><br>Also Due March 26th for 2018 National Rebuilding Day.</p>
+
+          {% elif a.name == "Fully Executed Signed Scope of Work" %}
+              <p class="small">On National Rebuilding Day (or within a few weeks after), please omplete all
+                          "primary tasks" on the scope of work, review the completion with the site
+                          owner, and have them sign at the bottom of the scope of work form (feel free
+                          to use the exact same document that was signed before work started). Please
+                          upload "Fully Executed Signed Scope of Work" here. This is RTP's way of
+                          recognizing that the Scope of work is complete and the site owner is in
+                          agreement. This is the final document needed.
+                          <br><br>Due May 23rd for 2018 National Rebuilding Today.</p>
+
+         {% endif %}
+
+
+
         {% if a.attached_file %}
             <a href="{{ a.attached_file.uri }}" class="move-right-1 small"> {{ a.attached_file.filename }} </a>
           &nbsp;&nbsp;<a href="{{ a.remove_uri }}" class="move-right-1 small"> remove </a>

--- a/gae/static/styles.css
+++ b/gae/static/styles.css
@@ -411,14 +411,6 @@ div.form-group.thumbnail{border:none}
     border-top: none;
     margin-top: -5px;
 }
-
-#simple-form-backform > div.form-group.order_form_helper  .help-block{
-  font-weight: bold;
-  font-size: 16px;
-  color: #333;
-  margin-top: 25px;
-}
-
 /* Displays help-text immediately under textarea */
 #order-logistics-form > div.form-group.notes {
   white-space: normal;

--- a/gae/static/styles.css
+++ b/gae/static/styles.css
@@ -418,3 +418,8 @@ div.form-group.thumbnail{border:none}
   color: #333;
   margin-top: 25px;
 }
+
+/* Displays help-text immediately under textarea */
+#order-logistics-form > div.form-group.notes {
+  white-space: normal;
+}

--- a/gae/static/styles.css
+++ b/gae/static/styles.css
@@ -411,3 +411,10 @@ div.form-group.thumbnail{border:none}
     border-top: none;
     margin-top: -5px;
 }
+
+#simple-form-backform > div.form-group.order_form_helper  .help-block{
+  font-weight: bold;
+  font-size: 16px;
+  color: #333;
+  margin-top: 25px;
+}


### PR DESCRIPTION
Test version here: [https://issue471-dot-rebuildingtogethercaptain-hrd.appspot.com](https://issue471-dot-rebuildingtogethercaptain-hrd.appspot.com)

All  _verbose_names_ have been removed from _ndb_models_ and placed in gae/ js/app/_view_ or _template_.
